### PR TITLE
terraform 0.12, mongodb 4.2 and oracle linux 8 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@
 - **public_subnet_id:** One of the public subnets to create the instance
 - **instance_type:** Instance type of the VPN box (t2.small is mostly enough)
 - **whitelist:** List of office IP addresses that you can SSH and non-VPN connected users can reach temporary profile download pages
-- **whitelist_http:** List of IP addresses that you can allow HTTP connections.
+- **whitelist_http:** List of IP addresses that you can allow HTTP connections for Let's Encrypt
 - **internal_cidrs:** List of CIDRs that will be whitelisted to access the VPN server internally.
 - **resource_name_prefix:** All the resources will be prefixed with the value of this variable
+- **volume_size:** instance volume size
 
 # Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,3 @@
-data "aws_region" "current" {}
-
 data "aws_caller_identity" "current" {}
 
 data "aws_ami" "oracle" {
@@ -7,7 +5,7 @@ data "aws_ami" "oracle" {
 
   filter {
     name   = "name"
-    values = ["OL7.6-x86_64-HVM-2019-01-29"]
+    values = ["OL8.2-x86_64-HVM-2020-05-22"]
   }
 
   filter {
@@ -15,7 +13,7 @@ data "aws_ami" "oracle" {
     values = ["hvm"]
   }
 
-  owners = ["131827586825"] # Canonical
+  owners = ["131827586825"] # Oracle
 }
 
 resource "aws_instance" "pritunl" {
@@ -24,48 +22,21 @@ resource "aws_instance" "pritunl" {
   key_name      = var.aws_key_name
   user_data     = file("${path.module}/provision.sh")
 
+	root_block_device {
+    volume_size = var.volume_size
+  }
+
   vpc_security_group_ids = [
     aws_security_group.pritunl.id,
     aws_security_group.allow_from_office.id,
   ]
 
   subnet_id                   = var.public_subnet_id
-  associate_public_ip_address = false
-
-  tags = "${
-    merge(
-      map("Name", format("%s-%s", var.resource_name_prefix, "vpn")),
-      var.tags,
-    )
-  }"
-
-  provisioner "remote-exec" {
-    inline = [
-      "sleep 60",
-      "sudo pritunl setup-key",
-    ]
-  }
-
-}
-
-data "aws_instance" "pritunl_loaded" {
-  depends_on = [
-    aws_instance.pritunl
-  ]
-
-  filter {
-    name   = "image-id"
-    values = [data.aws_ami.oracle.id]
-  }
-
-  filter {
-    name   = "tag:Name"
-    values = [format("%s-%s", var.resource_name_prefix, "vpn")]
-  }
-
+  associate_public_ip_address = true  
+  tags = merge( map("Name", format("%s-%s", var.resource_name_prefix, "vpn")), var.tags,)
 }
 
 resource "aws_eip" "pritunl" {
-  instance = "${aws_instance.pritunl.id}"
+  instance = aws_instance.pritunl.id
   vpc      = true
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,9 +1,9 @@
 output "pritunl_private_ip" {
-  value = "${aws_instance.pritunl.private_ip}"
+  value = aws_instance.pritunl.private_ip
 }
 
-output "pritunl_public_ip" {
-  value = "${aws_instance.pritunl.public_ip}"
+output "pritunl_elastic_ip" {
+  value = aws_eip.pritunl.public_ip
 }
 
 output "security_group_ids" {

--- a/provider.tf
+++ b/provider.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region = var.aws_region
+}

--- a/securitygroups.tf
+++ b/securitygroups.tf
@@ -11,6 +11,14 @@ resource "aws_security_group" "pritunl" {
     cidr_blocks = var.internal_cidrs
   }
 
+	# For Let's Encrypt validation
+	ingress {
+    from_port = 80
+    to_port   = 80
+    protocol  = "tcp"
+    cidr_blocks = var.whitelist_http
+  }
+
   # HTTPS access
   ingress {
     from_port   = 443

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -1,0 +1,7 @@
+aws_key_name = "mykey"
+vpc_id = "vpc-035505708a99422"
+whitelist = ["0.0.0.0/0"]
+public_subnet_id = "subnet-05645874433c61e"
+instance_type = "t3.micro"
+aws_region = "eu-west-1"
+volume_size = 10

--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,12 @@
 variable "aws_key_name" {
   description = "SSH keypair name for the VPN instance"
+	# default = "mykey"
 }
+
+variable "aws_region" {
+  description = "The aws region"
+}
+
 
 variable "vpc_id" {
   description = "Which VPC VPN server will be created in"
@@ -22,7 +28,7 @@ variable "whitelist" {
 }
 
 variable "whitelist_http" {
-  description = "[List] Whitelist for HTTP port"
+  description = "[List] Whitelist for HTTP port to validate Let's Encrypt SSL"
   type        = list(string)
   default     = ["0.0.0.0/0"]
 }
@@ -42,3 +48,10 @@ variable "internal_cidrs" {
   type        = list(string)
   default     = ["10.0.0.0/16"]
 }
+
+variable "volume_size" {
+  description = "ec2 volume size"
+  default = 20
+}
+
+

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
added terraform 0.12, mongodb 4.2 and oracle linux 8 support
Added dnspython install to use mongodb+srv for mongodb connection
removed remote-exec (pritunl setup-key does not configure anything)
removed unused  data "aws_instance" "pritunl_loaded
added volume_size parameter
